### PR TITLE
Remove deprecated `version` from `docker-compose.yml`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
-version: '3.8'
 
 services:
   db:
     image: postgres:15
     volumes:
-      - ./postgres_data:/var/lib/postgresql/data/
+      - postgres_data:/var/lib/postgresql/data/
     healthcheck:
       test: [ "CMD", "pg_isready", "-U", "grandchat", "-d", "grandchat" ]
       interval: 1s


### PR DESCRIPTION
#### What this PR does

1. Remove deprecated `version` from `docker-compose.yml`. Fix:
```shell
WARN[0000] /Users/qclaogui/grand-chat-tutorial/docker-compose.yml: `version` is obsolete
```
2. Use the defined volume `postgres_data` instead of a real directory on the host.